### PR TITLE
fix: npm: publish to getjerry

### DIFF
--- a/.npmrc-publish
+++ b/.npmrc-publish
@@ -1,0 +1,4 @@
+@getjerry:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+save-exact=true
+legacy-peer-deps=true

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "type": "git",
     "url": "https://github.com/getjerry/marksy"
   },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "scripts": {
     "build": "cross-env BABEL_ENV=production babel src/ --out-dir=lib/ -s && cp src/*.d.ts ./lib/",
     "lint": "cross-env NODE_ENV=production eslint --cache --cache-location=.cache/eslint --ext .js,.jsx,.json ./src ./app",


### PR DESCRIPTION
Publish to getjerry npm repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm publishing configuration to enable distribution via GitHub Packages with automatic authentication and exact dependency pinning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->